### PR TITLE
<수정 / 추가>

### DIFF
--- a/src/main/java/com/jamong/controller/MemberController.java
+++ b/src/main/java/com/jamong/controller/MemberController.java
@@ -73,7 +73,7 @@ public class MemberController {
 			mo.addAttribute("fail_id",fail_id);
 			session.removeAttribute("fail_id");
 		}
-
+		
 		if(m != null) {
 			out.println("<link rel=\"stylesheet\" type=\"text/css\" href=\"/jamong.com/resources/css/sweetalert2.css\" />\r\n" + 
 					"<script type=\"text/javascript\" src=\"/jamong.com/resources/js/sweetalert2.min.js\"></script>\r\n" + 

--- a/src/main/java/com/jamong/controller/OfferController.java
+++ b/src/main/java/com/jamong/controller/OfferController.java
@@ -50,6 +50,8 @@ public class OfferController {
 		
 		
 		if(m == null) {
+			String ref = request.getHeader("Referer");
+			session.setAttribute("ref", ref);
 			out.println("<link rel=\"stylesheet\" type=\"text/css\" href=\"/jamong.com/resources/css/sweetalert2.css\" />\r\n" + 
 					"<script type=\"text/javascript\" src=\"/jamong.com/resources/js/sweetalert2.min.js\"></script>\r\n" + 
 					"<body>\r\n" + 
@@ -66,6 +68,7 @@ public class OfferController {
 					"				location='/jamong.com/login';\r\n" + 
 					"			}else if(result.dismiss === Swal.DismissReason.cancel) {\r\n" + 
 					"				history.back();\r\n" + 
+					"				window.sessionStorage.removeItem('ref');\r\n" +
 					"			}\r\n" + 
 					"		});\r\n" + 
 					"</script>\r\n" + 

--- a/src/main/webapp/WEB-INF/views/include/header.jsp
+++ b/src/main/webapp/WEB-INF/views/include/header.jsp
@@ -30,8 +30,18 @@
  	 </a>
  	</div>
  	
- 	<div id="head-menu-empty">
  	<%-- 읽기페이지에 필요한 버튼 --%>
+ 	<c:if test="${! empty bo}">
+ 	 <div id="head-menu-readpage-info">
+ 	  <c:if test="${bo.cat_name ne null}">
+ 	   <a id="head-menu-readpage-cat" href="${pageContext.request.contextPath}/category/${bo.cat_name}">${bo.cat_name}</a>
+ 	  </c:if>
+ 	  <c:if test="${bo.book_no != 0}">
+ 	   <a id="head-menu-readpage-booklink" href="${pageContext.request.contextPath}/book/@${bo.memberVO.mem_id}/${bo.book_no}">Book</a>
+ 	  </c:if>
+ 	 </div>
+ 	</c:if>
+ 	<div id="head-menu-empty">
  	<c:if test="${! empty bo}">
  	<div id="head-menu-readpage">
  	 <c:if test="${(mem_id eq m.mem_id) && (bo.book_no == 0)}">

--- a/src/main/webapp/WEB-INF/views/index.jsp
+++ b/src/main/webapp/WEB-INF/views/index.jsp
@@ -419,7 +419,7 @@ $(document).keydown(function(e){
           <div class="recom_book-item-head">
            <div class="book-item-head-inner">
            <c:if test="${bolist.bookVO.book_cover eq null}">
-            <img class="book-item-head-inner-img" style="background-color:#f2f2f2">
+            <img class="book-item-head-inner-img" src="${pageContext.request.contextPath}/resources/img/book_cover.jpg">
            </c:if>
            <c:if test="${bolist.bookVO.book_cover ne null}">
             <img class="book-item-head-inner-img" src="${bolist.bookVO.book_cover}">

--- a/src/main/webapp/WEB-INF/views/jsp/accuse.jsp
+++ b/src/main/webapp/WEB-INF/views/jsp/accuse.jsp
@@ -70,9 +70,10 @@
 	    		 <!-- 기타사유 텍스트필드 끝 -->
 	    		 
 	    		 
-	    		 <p class="acc_write">권리침해 신고는 먼저 침해한 게시물을 신고 후 '자몽홈페이지 권리침해 신고 사이트'에서 침해증빙
-	    		  서류를 다운 받아 내용을 작성하여 <a class="acc_link_more" href="${pageContext.request.contextPath}/policy_privacy"
-  	    target="_blank">자몽 고객센터</a>로 온라인 접수하면 처리됩니다.
+	    		 <p class="acc_write">권리침해 신고는 먼저 침해한 게시물을 신고 후 <a href="https://privacy.kisa.or.kr/main.do" 
+	    		 target="_blank" style="color: #2c91ef;">'개인정보침해신고센터'</a>에서 침해증빙
+	    		  서류를 다운 받아 내용을 작성하여 <a class="acc_link_more" href="${pageContext.request.contextPath}/inquire"
+  	    		 target="_blank">자몽 고객센터</a>로 온라인 접수하면 처리됩니다.
 	    		 </p>
 	    		 <button type="submit" class="acc_report_btn">신고하기</button>
 	    		</form>

--- a/src/main/webapp/WEB-INF/views/jsp/book_create.jsp
+++ b/src/main/webapp/WEB-INF/views/jsp/book_create.jsp
@@ -9,8 +9,11 @@
  <div id="book_create_base">
  <div id="book_create_announce">
   <img id="book_create_anno_img" src="${pageContext.request.contextPath}/resources/img/alert.png" alt="주의">
-  <div id="book_create_anno_cont">  
-  	자몽에서는 작가님들의 책임있는 출판활동을 권고하기 위하여 완성된 책에 대한 수정 삭제 기능이 없음을 안내드립니다.
+  <div id="book_create_anno_cont" oncontextmenu="return false" ondragstart="return false" onselectstart="return false">  
+  	<span style="font-weight:bold;">책발간시 유의사항</span>
+  	<span>1. 자몽에서는 작가님들의 책임있는 출판활동을 권고하기 위하여 완성된 책에 대한 수정 삭제 기능이 없음을 안내드립니다.</span>
+  	<span>2. 비공개 처리된 글의 경우 발간되는 책에 추가하시게 되면 공개글로 자동 전환되며, 수정 및 비공개 처리하실 수 없습니다. </span>
+  	
   </div>
  </div>
   <form method="post" action="book_create_ok" onsubmit="return createBookCheck();" enctype="multipart/form-data">

--- a/src/main/webapp/WEB-INF/views/jsp/category.jsp
+++ b/src/main/webapp/WEB-INF/views/jsp/category.jsp
@@ -43,6 +43,11 @@
    </div>
    
     <!-- 글 내용부분 -->
+    <c:if test="${empty blist}">
+	 <div class=cat_writing_block>
+	  <h3>해당 카테고리에 검색결과가 없습니다!</h3>
+	 </div>
+	</c:if>
     <c:if test="${!empty blist}">
     <c:forEach var="blist" items="${blist}">
 	 <c:if test="${!empty blist.bo_thumbnail}">
@@ -144,18 +149,24 @@
 	  </c:if>
 	</c:forEach>
 	  </c:if>
-	  <c:if test="${empty blist}">
-	  <div class=cat_writing_block>
-	  <h3>해당 카테고리에 검색결과가 없습니다!</h3>
-	  </div>
-	  </c:if>
+	 
 	
 	<!-- 책부분 시작 -->
+	<c:if test="${empty bklist}">
+	 <div class=cat_book_block style="display:none;">
+	  <h3>해당 카테고리에 검색결과가 없습니다!</h3>
+	 </div>
+	</c:if>
    <c:if test="${!empty bklist}">
 	<div class=cat_book_block style="display:none;">	
 	<c:forEach var="bklist" items="${bklist}">
 	 <div class=cat_book onclick="location.href='${pageContext.request.contextPath}/book/@${bklist.memberVO.mem_id}/${bklist.bookVO.book_no}'">
-	   <img class="cat_book_img" src="${bklist.bookVO.book_cover }" alt="글" />
+	  <c:if test="${bklist.bookVO.book_cover ne null}">
+	   <img class="cat_book_img" src="${bklist.bookVO.book_cover }" alt="책" />
+	  </c:if>
+	  <c:if test="${bklist.bookVO.book_cover eq null}">
+	   <img class="cat_book_img" src="${pageContext.request.contextPath}/resources/img/book_cover.jpg" alt="책" />
+	  </c:if>
 		<div class="cat_book_inner">
 			<p class=cat_book_title><strong>${bklist.bookVO.book_name}</strong></p>
 			<span class=cat_story_writer><i>by</i>&nbsp;${bklist.memberVO.mem_nickname}</span>
@@ -165,12 +176,6 @@
 	 </div>
 	 </c:forEach>
 	</div>
-  </c:if>
-  
-   <c:if test="${empty bklist}">
-	  <div class=cat_book_block>
-	  <h3>해당 카테고리에 검색결과가 없습니다!</h3>
-	  </div>
-	  </c:if>		
+  </c:if>		
    </div>
 <%@ include file="../include/footer.jsp" %>

--- a/src/main/webapp/WEB-INF/views/jsp/notice.jsp
+++ b/src/main/webapp/WEB-INF/views/jsp/notice.jsp
@@ -126,9 +126,6 @@
 			<option value="noti_cont" <c:if test="${search_field == 'noti_cont'}">${'selected'}</c:if>>
 				내용
 			</option>
-			<option value="noti_name" <c:if test="${search_field == 'noti_name'}">${'selected'}</c:if>>
-				작성자
-			</option>
 		</select>
 		<input name="search_name" id="search_name" size="15" value="${search_name}" />
 		<input type="submit" value="검색" class="notice_btn"/>

--- a/src/main/webapp/WEB-INF/views/jsp/search_result.jsp
+++ b/src/main/webapp/WEB-INF/views/jsp/search_result.jsp
@@ -80,7 +80,7 @@
 	        <div class="post_cont_catbook">
 	         <a href="${pageContext.request.contextPath}/category/${board.cat_name}" class="post_cont_cat">${board.cat_name}</a>
 	         <c:if test="${board.book_no ne 0}">
-	          <span class="post_cont_book">Book</span>
+	          <a class="post_cont_book" href="${pageContext.request.contextPath}/book/@${board.memberVO.mem_id}/${board.book_no}">Book</a>
 	         </c:if>
 	        </div>
 	        <a href="${pageContext.request.contextPath}/@${board.memberVO.mem_id}/${board.bo_no}">  
@@ -130,7 +130,7 @@
 	    <a href="${pageContext.request.contextPath}/book/@${bookList.memberVO.mem_id}/${bookList.bookVO.book_no}" class="scrolling" data-no="${status.count}">
 	     <div class="work_cont">
 	      <c:if test="${bookList.bookVO.book_cover eq null}">
-		   <img id="work_img" style="background-color:#f2f2f2">
+		   <img id="work_img" src="${pageContext.request.contextPath}/resources/img/book_cover.jpg">
 	      </c:if>
 	      <c:if test="${bookList.bookVO.book_cover ne null}">
 		   <img id="work_img" src="${bookList.bookVO.book_cover}" alt="표지">

--- a/src/main/webapp/resources/css/book_create.css
+++ b/src/main/webapp/resources/css/book_create.css
@@ -37,10 +37,46 @@ a {
 	width:25px;
 	height:25px;
 	object-fit:cover;
+	cursor: pointer;
+}
+
+#book_create_anno_img:hover ~#book_create_anno_cont{
+	display:inline;
+	opacity:1;
 }
 
 #book_create_anno_cont{
-	
+    cursor: default;
+    padding: 7px;
+    position: relative;
+    width: 730px;
+    bottom: 50px;
+    z-index: 10;
+    font-size: 14px;
+    background-color:#f9cc5bde;
+ 	opacity:0;
+ 	display:inline;
+    -webkit-transition:display 1s, opacity 1s;
+    transition:display 1s, opacity 1s;
+    animation-name: anno;
+  	animation-duration:4s;
+}
+
+@-webkit-keyframes anno{
+  0% {
+    opacity:1;
+  }
+  80%{
+  	opacity:1;
+  }
+  100% {
+    opacity:0;
+  }
+}
+
+#book_create_anno_cont span{
+	display:inline-block;
+	line-height: 22px;
 }
 
 #book_create_info {

--- a/src/main/webapp/resources/css/book_info.css
+++ b/src/main/webapp/resources/css/book_info.css
@@ -63,6 +63,7 @@ a {
     padding-top: 30px;
     font-size: 23px;
     height: 150px;
+    line-height: 30px;
 }
 #book_info_cover_author{
 	display: block;

--- a/src/main/webapp/resources/css/category.css
+++ b/src/main/webapp/resources/css/category.css
@@ -316,7 +316,7 @@ body{
     font-size:12px;
     font-weight:bold;
     position: absolute;
-    color:#ffffff;
+    color:#3d3d3d;
     transform: translateX(-50%);
     top: 90%;
     left: 50%

--- a/src/main/webapp/resources/css/header.css
+++ b/src/main/webapp/resources/css/header.css
@@ -103,6 +103,50 @@ body{
 	margin-top: 2px;
 }
 
+#head-menu-readpage-info{
+	display: flex;
+    align-items: center;
+	height: 55px;
+    line-height: 55px;
+    padding-top: 5px;
+    min-width: 150px;
+    margin-left: 53px;
+    font-family: 'NanumMyeongjo','serif';
+}
+
+#head-menu-readpage-cat{
+    color: #ff8040;
+    font-size: 12px;
+    font-weight: bold;
+    margin-right: 10px;
+    border: 1px solid #ff8040;
+    border-radius: 23px;
+    padding: 2px 8px;
+    line-height: 19px;
+}
+
+#head-menu-readpage-cat:hover{
+	color: #fff;
+	background-color: #ff8040;	
+}
+
+#head-menu-readpage-booklink{
+	color: #e0849d;
+    font-size: 15px;
+    font-weight: bold;
+    height: 30px;
+    margin-top: 0px;
+    padding-top: 0px;
+    line-height: 30px;
+}
+#head-menu-readpage-booklink:hover{
+	text-decoration: underline;
+}
+
+#head-menu-readpage-empty{
+	width: calc(50vw - 428px);
+}
+
 #head-menu-lock{
 	height:30px;
 	margin-right:25px;

--- a/src/main/webapp/resources/css/m.css
+++ b/src/main/webapp/resources/css/m.css
@@ -943,7 +943,7 @@ body{
 }
 .recom_author-item-intro strong{
 	font-family: 'NanumMyeongjo','serif';
-	font-size:20px;
+	font-size:16px;
 	color:#333;
 	display:block;
 	margin-top:15px;

--- a/src/main/webapp/resources/css/search_result.css
+++ b/src/main/webapp/resources/css/search_result.css
@@ -178,6 +178,9 @@ ul li {
 .post_cont_book{
 	color:#e0849d;
 }
+.post_cont_book:hover{
+	text-decoration: underline;
+}
 
 .post_img_wrap{
 	margin-top: 25px;

--- a/src/main/webapp/resources/js/inquire.js
+++ b/src/main/webapp/resources/js/inquire.js
@@ -1,8 +1,10 @@
 /**
  *  inquire.jsp inquire.css
  */
+var regExpEamil = RegExp(/^(?=.*[@]{1,50})(?=.*[\.]{1,50}).{1,50}$/); //@와 .이 반드시 들어가게 만드는 정규식
 
 function inq(){
+	$('.inq_vali_date').text('');
 	if($("#listselect option:selected").val() == "none"){
 		$('#inq_vali_list').text('목록을 선택해주세요.');
 		$("#listselect").focus();
@@ -13,8 +15,18 @@ function inq(){
 		$('#email').focus();
 		return false;
 	}
+	if(!regExpEamil.test($("#email").val())){	//이메일 정규식 양식 체크
+		$('#inq_vali_email').text('E-mail을 정확하게 입력해주세요.');
+		$('#email').focus();
+		return false
+	}
 	if($('#phone').val() == ""){
 		$('#inq_vali_phone').text('Phone번호를 입력해 주세요.');
+		$('#phone').focus();
+		return false;
+	}
+	if($('#phone').val().length<8){
+		$('#inq_vali_phone').text('Phone번호를 정확하게 입력해 주세요.');
 		$('#phone').focus();
 		return false;
 	}

--- a/src/main/webapp/resources/js/login.js
+++ b/src/main/webapp/resources/js/login.js
@@ -71,9 +71,6 @@ $(document).ready(function(){
 	});
 	
 	$("#login_pwd").on("keyup keydown", function(key){
-		if (key.keyCode == 13) {
-			$("#login_btn").trigger("click");
-		}
 		 if(key.type === 'keydown'){
 	          if(key.keyCode == 32) {
 	             return false;

--- a/src/main/webapp/resources/js/main.js
+++ b/src/main/webapp/resources/js/main.js
@@ -5,6 +5,7 @@
 //js페이지가 로딩되면 메뉴에 요소들을 불러옴(중단에 메서드 있음)
 var slideIndex = 0;
 var timerID;
+var buttonTimerID;
 getCategory();
 getBestList();
 getHeaderNotice();
@@ -81,6 +82,7 @@ function hotscroll(where,number){
 }
 
 function showSlides() {
+	clearTimeout(buttonTimerID);
 	if($('#recom_book-cont').length>0){
 		slideIndex++;
 		if (slideIndex > 3) {slideIndex = 1}    
@@ -108,7 +110,7 @@ function slideButton(a){
 	$('.recom-book-page').attr("data-disabled",'true');
 	clearTimeout(timerID);
 	slideIndex = a;
-	timerID = setTimeout(showSlides, 1000);
+	buttonTimerID = setTimeout(showSlides, 1000);
 	setTimeout(function(){
 		$('.recom-book-page').attr("data-disabled",'false');
 	},2000);


### PR DESCRIPTION
작가 제안
- 비로그인 작가제안시 로그인 후 이동페이지를 이전페이지로 인식

책발간 페이지
- 책 발간전에 주의사항이 4초동안 떠있다가 사라지게 제작
- 이후 경고표시에 hover시에 다시 확인 가능

검색
- 글 검색시에 책에 포함된 글이라면 book을 클릭하여 글 상세페이지로 이동가능

글읽기
- header에 카테고리 & book 표시
- 해당 카테고리 페이지 혹은 책 상세페이지로 이동 가능

문의페이지
- 이메일 검증 확실하게 (@ . 이 없으면 진행막음)
- 전화번호 검증확실하게 (전화번호 9글자 이상만 통과)

로그인
- 로그인시 엔터쳐서 로그인하면 로그인 확인 문구 뜨는 현상 교정

메인
- 추천책란 버튼 클릭시 빠르게 돌아가버리던 현상 수정

공지사항(사용자)
- 글쓴이 검색란 삭제
메인, 검색, 카테고리 페이지의 책
- 겉표지가 없을경우 null값으로 이미지 추가